### PR TITLE
게시글 저장시 유저 정보도 포함하여 저장

### DIFF
--- a/src/main/java/joo/project/my3dbackend/api/ArticleApi.java
+++ b/src/main/java/joo/project/my3dbackend/api/ArticleApi.java
@@ -2,6 +2,7 @@ package joo.project.my3dbackend.api;
 
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
 import joo.project.my3dbackend.exception.ArticleException;
 import joo.project.my3dbackend.exception.constants.ErrorCode;
 import joo.project.my3dbackend.service.ArticleServiceInterface;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,14 +34,14 @@ public class ArticleApi {
      */
     @PostMapping
     public ResponseEntity<?> writeArticle(
-            @RequestBody @Valid ArticleRequest articleRequest, BindingResult bindingResult) {
+            @RequestBody @Valid ArticleRequest articleRequest, BindingResult bindingResult, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         if (bindingResult.hasErrors()) {
             log.error("bindingResult: {}", bindingResult);
             // TODO: bindingResult에서 어떤 필드가 문제인지 메시지와 함께 전달
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ArticleException(ErrorCode.FAILED_WRITE_ARTICLE));
         }
-        ArticleDto articleDto = articleService.writeArticle(articleRequest);
+        ArticleDto articleDto = articleService.writeArticle(articleRequest, userPrincipal);
         return ResponseEntity.status(HttpStatus.CREATED).body(articleDto);
     }
 }

--- a/src/main/java/joo/project/my3dbackend/domain/Article.java
+++ b/src/main/java/joo/project/my3dbackend/domain/Article.java
@@ -59,17 +59,28 @@ public class Article extends AuditingAt implements Persistable<Long> {
     private boolean isFree;
 
     private Article(
-            String title, String content, ArticleType articleType, ArticleCategory articleCategory, boolean isFree) {
+            String title,
+            String content,
+            ArticleType articleType,
+            ArticleCategory articleCategory,
+            boolean isFree,
+            UserAccount userAccount) {
         this.title = title;
         this.content = content;
         this.articleType = articleType;
         this.articleCategory = articleCategory;
         this.isFree = isFree;
+        this.userAccount = userAccount;
     }
 
     public static Article of(
-            String title, String content, ArticleType articleType, ArticleCategory articleCategory, boolean isFree) {
-        return new Article(title, content, articleType, articleCategory, isFree);
+            String title,
+            String content,
+            ArticleType articleType,
+            ArticleCategory articleCategory,
+            boolean isFree,
+            UserAccount userAccount) {
+        return new Article(title, content, articleType, articleCategory, isFree, userAccount);
     }
 
     @Override

--- a/src/main/java/joo/project/my3dbackend/domain/Article.java
+++ b/src/main/java/joo/project/my3dbackend/domain/Article.java
@@ -39,8 +39,11 @@ public class Article extends AuditingAt implements Persistable<Long> {
 
     @ToString.Exclude
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "userAccountId")
+    @JoinColumn(name = "userAccountId", insertable = false, updatable = false)
     private UserAccount userAccount;
+
+    @Column(nullable = false)
+    private Long userAccountId;
 
     @PreUpdate
     void modifiedAt() {
@@ -64,13 +67,13 @@ public class Article extends AuditingAt implements Persistable<Long> {
             ArticleType articleType,
             ArticleCategory articleCategory,
             boolean isFree,
-            UserAccount userAccount) {
+            Long userAccountId) {
         this.title = title;
         this.content = content;
         this.articleType = articleType;
         this.articleCategory = articleCategory;
         this.isFree = isFree;
-        this.userAccount = userAccount;
+        this.userAccountId = userAccountId;
     }
 
     public static Article of(
@@ -79,8 +82,8 @@ public class Article extends AuditingAt implements Persistable<Long> {
             ArticleType articleType,
             ArticleCategory articleCategory,
             boolean isFree,
-            UserAccount userAccount) {
-        return new Article(title, content, articleType, articleCategory, isFree, userAccount);
+            Long userAccountId) {
+        return new Article(title, content, articleType, articleCategory, isFree, userAccountId);
     }
 
     @Override

--- a/src/main/java/joo/project/my3dbackend/dto/ArticleDto.java
+++ b/src/main/java/joo/project/my3dbackend/dto/ArticleDto.java
@@ -3,6 +3,10 @@ package joo.project.my3dbackend.dto;
 import joo.project.my3dbackend.domain.Article;
 import joo.project.my3dbackend.domain.constants.ArticleCategory;
 import joo.project.my3dbackend.domain.constants.ArticleType;
+import joo.project.my3dbackend.domain.constants.UserRole;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
+
+import java.time.LocalDateTime;
 
 public record ArticleDto(
         Long id,
@@ -10,14 +14,22 @@ public record ArticleDto(
         String content,
         ArticleType articleType,
         ArticleCategory articleCategory,
-        boolean isFree) {
-    public static ArticleDto fromEntity(Article article) {
+        boolean isFree,
+        String nickname,
+        UserRole userRole,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt) {
+    public static ArticleDto fromEntity(Article article, UserPrincipal userPrincipal) {
         return new ArticleDto(
                 article.getId(),
                 article.getTitle(),
                 article.getContent(),
                 article.getArticleType(),
                 article.getArticleCategory(),
-                article.isFree());
+                article.isFree(),
+                userPrincipal.nickname(),
+                userPrincipal.getUserRole(),
+                article.getCreatedAt(),
+                article.getModifiedAt());
     }
 }

--- a/src/main/java/joo/project/my3dbackend/dto/request/ArticleRequest.java
+++ b/src/main/java/joo/project/my3dbackend/dto/request/ArticleRequest.java
@@ -32,8 +32,8 @@ public class ArticleRequest {
     // TODO: modelFile(dimension)
     // TODO: userAccount
 
-    public Article toEntity(UserAccount userAccount) {
+    public Article toEntity(Long userAccountId) {
         // TODO: model 파일이 있을 경우 ArticleType.MODEL, 없으면 TEXT
-        return Article.of(title, content, ArticleType.TEXT, ArticleCategory.valueOf(articleCategory), isFree, userAccount);
+        return Article.of(title, content, ArticleType.TEXT, ArticleCategory.valueOf(articleCategory), isFree, userAccountId);
     }
 }

--- a/src/main/java/joo/project/my3dbackend/dto/request/ArticleRequest.java
+++ b/src/main/java/joo/project/my3dbackend/dto/request/ArticleRequest.java
@@ -1,6 +1,7 @@
 package joo.project.my3dbackend.dto.request;
 
 import joo.project.my3dbackend.domain.Article;
+import joo.project.my3dbackend.domain.UserAccount;
 import joo.project.my3dbackend.domain.constants.ArticleCategory;
 import joo.project.my3dbackend.domain.constants.ArticleType;
 import joo.project.my3dbackend.dto.request.validation.ValidEnum;
@@ -31,8 +32,8 @@ public class ArticleRequest {
     // TODO: modelFile(dimension)
     // TODO: userAccount
 
-    public Article toEntity() {
+    public Article toEntity(UserAccount userAccount) {
         // TODO: model 파일이 있을 경우 ArticleType.MODEL, 없으면 TEXT
-        return Article.of(title, content, ArticleType.TEXT, ArticleCategory.valueOf(articleCategory), isFree);
+        return Article.of(title, content, ArticleType.TEXT, ArticleCategory.valueOf(articleCategory), isFree, userAccount);
     }
 }

--- a/src/main/java/joo/project/my3dbackend/dto/security/UserPrincipal.java
+++ b/src/main/java/joo/project/my3dbackend/dto/security/UserPrincipal.java
@@ -26,6 +26,13 @@ public record UserPrincipal(
                 userAccount.getUserRole());
     }
 
+    public UserRole getUserRole() {
+        return authorities.stream()
+                .map(r -> UserRole.valueOf(r.getAuthority().substring(5)))
+                .findFirst()
+                .orElse(UserRole.ANONYMOUS);
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;

--- a/src/main/java/joo/project/my3dbackend/service/ArticleServiceInterface.java
+++ b/src/main/java/joo/project/my3dbackend/service/ArticleServiceInterface.java
@@ -2,11 +2,12 @@ package joo.project.my3dbackend.service;
 
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
 
 public interface ArticleServiceInterface {
 
     /**
      * 게시글 작성
      */
-    ArticleDto writeArticle(ArticleRequest articleRequest);
+    ArticleDto writeArticle(ArticleRequest articleRequest, UserPrincipal userPrincipal);
 }

--- a/src/main/java/joo/project/my3dbackend/service/UserAccountServiceInterface.java
+++ b/src/main/java/joo/project/my3dbackend/service/UserAccountServiceInterface.java
@@ -8,9 +8,4 @@ public interface UserAccountServiceInterface {
      * 이메일로 유저 정보 조회
      */
     UserAccount getUserAccountByEmail(String email);
-
-    /**
-     * id로 유저 reference 조회
-     */
-    UserAccount getReferenceUserAccountById(Long userAccountId);
 }

--- a/src/main/java/joo/project/my3dbackend/service/UserAccountServiceInterface.java
+++ b/src/main/java/joo/project/my3dbackend/service/UserAccountServiceInterface.java
@@ -5,7 +5,12 @@ import joo.project.my3dbackend.domain.UserAccount;
 public interface UserAccountServiceInterface {
 
     /**
-     * 유저 정보 조회
+     * 이메일로 유저 정보 조회
      */
     UserAccount getUserAccountByEmail(String email);
+
+    /**
+     * id로 유저 reference 조회
+     */
+    UserAccount getReferenceUserAccountById(Long userAccountId);
 }

--- a/src/main/java/joo/project/my3dbackend/service/impl/ArticleService.java
+++ b/src/main/java/joo/project/my3dbackend/service/impl/ArticleService.java
@@ -1,13 +1,11 @@
 package joo.project.my3dbackend.service.impl;
 
 import joo.project.my3dbackend.domain.Article;
-import joo.project.my3dbackend.domain.UserAccount;
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
 import joo.project.my3dbackend.dto.security.UserPrincipal;
 import joo.project.my3dbackend.repository.ArticleRepository;
 import joo.project.my3dbackend.service.ArticleServiceInterface;
-import joo.project.my3dbackend.service.UserAccountServiceInterface;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,12 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ArticleService implements ArticleServiceInterface {
     private final ArticleRepository articleRepository;
-    private final UserAccountServiceInterface userAccountService;
 
     @Override
     public ArticleDto writeArticle(ArticleRequest articleRequest, UserPrincipal userPrincipal) {
-        UserAccount writer = userAccountService.getReferenceUserAccountById(userPrincipal.id());
-        Article savedArticle = articleRepository.save(articleRequest.toEntity(writer));
+        Article savedArticle = articleRepository.save(articleRequest.toEntity(userPrincipal.id()));
         return ArticleDto.fromEntity(savedArticle, userPrincipal);
     }
 }

--- a/src/main/java/joo/project/my3dbackend/service/impl/ArticleService.java
+++ b/src/main/java/joo/project/my3dbackend/service/impl/ArticleService.java
@@ -1,23 +1,30 @@
 package joo.project.my3dbackend.service.impl;
 
 import joo.project.my3dbackend.domain.Article;
+import joo.project.my3dbackend.domain.UserAccount;
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
 import joo.project.my3dbackend.repository.ArticleRepository;
 import joo.project.my3dbackend.service.ArticleServiceInterface;
+import joo.project.my3dbackend.service.UserAccountServiceInterface;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ArticleService implements ArticleServiceInterface {
     private final ArticleRepository articleRepository;
+    private final UserAccountServiceInterface userAccountService;
 
     @Override
-    public ArticleDto writeArticle(ArticleRequest articleRequest) {
-        Article savedArticle = articleRepository.save(articleRequest.toEntity());
-        return ArticleDto.fromEntity(savedArticle);
+    public ArticleDto writeArticle(ArticleRequest articleRequest, UserPrincipal userPrincipal) {
+        UserAccount writer = userAccountService.getReferenceUserAccountById(userPrincipal.id());
+        Article savedArticle = articleRepository.save(articleRequest.toEntity(writer));
+        return ArticleDto.fromEntity(savedArticle, userPrincipal);
     }
 }

--- a/src/main/java/joo/project/my3dbackend/service/impl/UserAccountService.java
+++ b/src/main/java/joo/project/my3dbackend/service/impl/UserAccountService.java
@@ -21,9 +21,4 @@ public class UserAccountService implements UserAccountServiceInterface {
     public UserAccount getUserAccountByEmail(String email) {
         return userAccountRepository.findByEmail(email).orElseThrow(() -> new AuthException(ErrorCode.NOT_FOUND_USER));
     }
-
-    @Override
-    public UserAccount getReferenceUserAccountById(Long userAccountId) {
-        return userAccountRepository.getReferenceById(userAccountId);
-    }
 }

--- a/src/main/java/joo/project/my3dbackend/service/impl/UserAccountService.java
+++ b/src/main/java/joo/project/my3dbackend/service/impl/UserAccountService.java
@@ -8,9 +8,11 @@ import joo.project.my3dbackend.service.UserAccountServiceInterface;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserAccountService implements UserAccountServiceInterface {
     private final UserAccountRepository userAccountRepository;
@@ -18,5 +20,10 @@ public class UserAccountService implements UserAccountServiceInterface {
     @Override
     public UserAccount getUserAccountByEmail(String email) {
         return userAccountRepository.findByEmail(email).orElseThrow(() -> new AuthException(ErrorCode.NOT_FOUND_USER));
+    }
+
+    @Override
+    public UserAccount getReferenceUserAccountById(Long userAccountId) {
+        return userAccountRepository.getReferenceById(userAccountId);
     }
 }

--- a/src/test/java/joo/project/my3dbackend/api/ArticleApiTest.java
+++ b/src/test/java/joo/project/my3dbackend/api/ArticleApiTest.java
@@ -2,21 +2,25 @@ package joo.project.my3dbackend.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import joo.project.my3dbackend.config.TestSecurityConfig;
+import joo.project.my3dbackend.domain.UserAccount;
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
+import joo.project.my3dbackend.fixture.Fixture;
 import joo.project.my3dbackend.fixture.FixtureDto;
 import joo.project.my3dbackend.service.ArticleServiceInterface;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,13 +43,16 @@ class ArticleApiTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("게시글 작성")
     @Test
     void writeArticle() throws Exception {
         // given
         ArticleRequest articleRequest = FixtureDto.createArticleRequest();
-        given(articleService.writeArticle(any(ArticleRequest.class)))
-                .willReturn(ArticleDto.fromEntity(articleRequest.toEntity()));
+        UserAccount userAccount = Fixture.createUserAccount();
+        UserPrincipal userPrincipal = FixtureDto.createUserPrincipal();
+        given(articleService.writeArticle(any(ArticleRequest.class), any(UserPrincipal.class)))
+                .willReturn(ArticleDto.fromEntity(articleRequest.toEntity(userAccount), userPrincipal));
         // when
         mvc.perform(post("/api/v1/articles")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/joo/project/my3dbackend/api/ArticleApiTest.java
+++ b/src/test/java/joo/project/my3dbackend/api/ArticleApiTest.java
@@ -9,6 +9,7 @@ import joo.project.my3dbackend.dto.security.UserPrincipal;
 import joo.project.my3dbackend.fixture.Fixture;
 import joo.project.my3dbackend.fixture.FixtureDto;
 import joo.project.my3dbackend.service.ArticleServiceInterface;
+import org.assertj.core.internal.Longs;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,10 +50,10 @@ class ArticleApiTest {
     void writeArticle() throws Exception {
         // given
         ArticleRequest articleRequest = FixtureDto.createArticleRequest();
-        UserAccount userAccount = Fixture.createUserAccount();
+        Long userAccountId = 1L;
         UserPrincipal userPrincipal = FixtureDto.createUserPrincipal();
         given(articleService.writeArticle(any(ArticleRequest.class), any(UserPrincipal.class)))
-                .willReturn(ArticleDto.fromEntity(articleRequest.toEntity(userAccount), userPrincipal));
+                .willReturn(ArticleDto.fromEntity(articleRequest.toEntity(userAccountId), userPrincipal));
         // when
         mvc.perform(post("/api/v1/articles")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/joo/project/my3dbackend/config/TestSecurityConfig.java
+++ b/src/test/java/joo/project/my3dbackend/config/TestSecurityConfig.java
@@ -1,13 +1,32 @@
 package joo.project.my3dbackend.config;
 
+import joo.project.my3dbackend.domain.Address;
+import joo.project.my3dbackend.domain.UserAccount;
+import joo.project.my3dbackend.domain.constants.UserRole;
+import joo.project.my3dbackend.fixture.Fixture;
 import joo.project.my3dbackend.security.SecurityConfig;
 import joo.project.my3dbackend.service.impl.UserAccountService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
-
     @MockBean
     private UserAccountService userAccountService;
+
+    @BeforeTestMethod
+    void securitySetUp() {
+        String userEmail = "testUser@gmail.com";
+        given(userAccountService.getUserAccountByEmail(eq(userEmail)))
+                .willReturn(createUserAccount(userEmail));
+    }
+
+    private UserAccount createUserAccount(String email) {
+        return Fixture.createUserAccount(email, "pw", "test", "01011112222", Address.of("12345", "street", "detail"), UserRole.USER);
+    }
+
 }

--- a/src/test/java/joo/project/my3dbackend/fixture/Fixture.java
+++ b/src/test/java/joo/project/my3dbackend/fixture/Fixture.java
@@ -4,15 +4,15 @@ import joo.project.my3dbackend.domain.Address;
 import joo.project.my3dbackend.domain.UserAccount;
 import joo.project.my3dbackend.domain.constants.UserRole;
 
-import javax.swing.*;
-
 public class Fixture {
 
-    public static UserAccount createUserAccount(String email, String password, String nickname, String phone, Address address, UserRole userRole) {
+    public static UserAccount createUserAccount(
+            String email, String password, String nickname, String phone, Address address, UserRole userRole) {
         return UserAccount.of(email, password, nickname, phone, address, userRole);
     }
 
     public static UserAccount createUserAccount() {
-        return createUserAccount("test@gmail.com", "pw", "test", "01012341234", Address.of("12345", "street", "detail"), UserRole.USER);
+        return createUserAccount(
+                "testUser@gmail.com", "pw", "testUser", "01012341234", Address.of("12345", "street", "detail"), UserRole.USER);
     }
 }

--- a/src/test/java/joo/project/my3dbackend/fixture/FixtureDto.java
+++ b/src/test/java/joo/project/my3dbackend/fixture/FixtureDto.java
@@ -1,6 +1,11 @@
 package joo.project.my3dbackend.fixture;
 
+import joo.project.my3dbackend.domain.constants.UserRole;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Set;
 
 public class FixtureDto {
 
@@ -16,5 +21,14 @@ public class FixtureDto {
 
     public static ArticleRequest createArticleRequest() {
         return createArticleRequest("title", "content", "MUSIC", true);
+    }
+
+    public static UserPrincipal createUserPrincipal(
+            Long id, String email, String password, UserRole userRole, String nickname) {
+        return new UserPrincipal(id, email, password, Set.of(new SimpleGrantedAuthority(userRole.getName())), nickname);
+    }
+
+    public static UserPrincipal createUserPrincipal() {
+        return createUserPrincipal(1L, "testUser@gmail.com", "pw", UserRole.USER, "testUser");
     }
 }

--- a/src/test/java/joo/project/my3dbackend/service/impl/ArticleServiceTest.java
+++ b/src/test/java/joo/project/my3dbackend/service/impl/ArticleServiceTest.java
@@ -4,6 +4,8 @@ import joo.project.my3dbackend.domain.Article;
 import joo.project.my3dbackend.domain.constants.ArticleCategory;
 import joo.project.my3dbackend.dto.ArticleDto;
 import joo.project.my3dbackend.dto.request.ArticleRequest;
+import joo.project.my3dbackend.dto.security.UserPrincipal;
+import joo.project.my3dbackend.fixture.Fixture;
 import joo.project.my3dbackend.fixture.FixtureDto;
 import joo.project.my3dbackend.repository.ArticleRepository;
 import org.junit.jupiter.api.*;
@@ -15,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 @ActiveProfiles("test")
@@ -26,6 +29,8 @@ class ArticleServiceTest {
 
     @Mock
     private ArticleRepository articleRepository;
+    @Mock
+    private UserAccountService userAccountService;
 
     @Order(0)
     @DisplayName("게시글 작성")
@@ -33,9 +38,13 @@ class ArticleServiceTest {
     void writeArticle() {
         // given
         ArticleRequest articleRequest = FixtureDto.createArticleRequest();
-        given(articleRepository.save(any(Article.class))).willReturn(articleRequest.toEntity());
+        UserPrincipal userPrincipal = FixtureDto.createUserPrincipal();
+        given(userAccountService.getReferenceUserAccountById(anyLong()))
+                .willReturn(Fixture.createUserAccount());
+        given(articleRepository.save(any(Article.class)))
+                .willReturn(articleRequest.toEntity(Fixture.createUserAccount()));
         // when
-        ArticleDto articleDto = articleService.writeArticle(articleRequest);
+        ArticleDto articleDto = articleService.writeArticle(articleRequest, userPrincipal);
         // then
         assertThat(articleDto.title()).isEqualTo("title");
         assertThat(articleDto.content()).isEqualTo("content");

--- a/src/test/java/joo/project/my3dbackend/service/impl/ArticleServiceTest.java
+++ b/src/test/java/joo/project/my3dbackend/service/impl/ArticleServiceTest.java
@@ -29,20 +29,17 @@ class ArticleServiceTest {
 
     @Mock
     private ArticleRepository articleRepository;
-    @Mock
-    private UserAccountService userAccountService;
 
     @Order(0)
     @DisplayName("게시글 작성")
     @Test
     void writeArticle() {
         // given
+        Long userAccountId = 1L;
         ArticleRequest articleRequest = FixtureDto.createArticleRequest();
         UserPrincipal userPrincipal = FixtureDto.createUserPrincipal();
-        given(userAccountService.getReferenceUserAccountById(anyLong()))
-                .willReturn(Fixture.createUserAccount());
         given(articleRepository.save(any(Article.class)))
-                .willReturn(articleRequest.toEntity(Fixture.createUserAccount()));
+                .willReturn(articleRequest.toEntity(userAccountId));
         // when
         ArticleDto articleDto = articleService.writeArticle(articleRequest, userPrincipal);
         // then

--- a/src/test/java/joo/project/my3dbackend/service/impl/UserAccountServiceTest.java
+++ b/src/test/java/joo/project/my3dbackend/service/impl/UserAccountServiceTest.java
@@ -19,18 +19,20 @@ import static org.mockito.BDDMockito.given;
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class UserAccountServiceTest {
-    @InjectMocks private UserAccountService userAccountService;
-    @Mock private UserAccountRepository userAccountRepository;
+    @InjectMocks
+    private UserAccountService userAccountService;
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
 
     @DisplayName("이메일로 유저 조회")
     @Test
     void getUserAccountByEmail() {
-        //given
+        // given
         UserAccount userAccount = Fixture.createUserAccount();
         given(userAccountRepository.findByEmail(anyString())).willReturn(Optional.of(userAccount));
-        //when
+        // when
         userAccountService.getUserAccountByEmail(userAccount.getEmail());
-        //then
+        // then
     }
-
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 게시글 저장시 `@AuthenticationPrincipal`를 사용하여 현재 인증된 유저 정보를 가져와 같이 저장해야하는데 인증 기능이 뒤늦게 구현되어 적용할 수가 없었습니다. 현재는 인증 기능이 구현되어 게시글 저장시 유저정보를 포함시켜야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- Article 생성자에 UserAccount 추가
- ArticleDTO에 작성자 닉네임과 role, 생성일시, 수정일시 정보 추가
    - 개인 유저인지 기업 유저인지 판단(표시)할 수 있도록 userRole도 포함시켰습니다.
- API 및 비지니스 로직 수정 
    - UserAccount를 조회하여 게시글을 저장할 때 Select가 발생하지 않도록 reference(proxy) 객체를 사용했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- `@Transactional` 적용

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2: 적극적으로 고려해 주세요 (Request changes)
    * P3: 웬만하면 반영해 주세요 (Comment)
    * P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
    * P5: 그냥 사소한 의견입니다 (Approve)

## Issue Tags
- Closed: #20 
